### PR TITLE
Fix consensus_encode_vec length calculation

### DIFF
--- a/src/dogecoin/src/block.rs
+++ b/src/dogecoin/src/block.rs
@@ -343,8 +343,8 @@ mod tests {
 
         // println!("Block root: {:?}", blk.auxpow);
 
-        let mut buf = Vec::new();
-        blk.consensus_encode(&mut buf).unwrap();
+        // serialize also asserts len is correct
+        let buf = bitcoin::consensus::encode::serialize(&blk);
         assert_eq!(buf, data);
 
         // println!("Tx 0: {:?}", blk.txdata[0]);

--- a/src/dogecoin/src/lib.rs
+++ b/src/dogecoin/src/lib.rs
@@ -22,7 +22,7 @@ where
     W: Write + ?Sized,
 {
     let mut len = 0;
-    VarInt::from(vv.len()).consensus_encode(w)?;
+    len += VarInt::from(vv.len()).consensus_encode(w)?;
     for v in vv.iter() {
         len += v.consensus_encode(w)?;
     }


### PR DESCRIPTION
Fix a bug in the length calculation of consensus_encode_vec.